### PR TITLE
chore: #patch add condition to check for 'release' label before tagging and …

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,7 +18,7 @@ jobs:
     name: Tag and Release
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
…releasing #patch
This pull request updates the release workflow to include an additional condition for tagging and releasing. The most important change is as follows:

### Workflow Condition Update:
* [`.github/workflows/release-publish.yml`](diffhunk://#diff-c6d47dacf31662f6791d0cf218b1d34ee0ab48348c037819431cdd40e3fc23e4L21-R21): Modified the `if` condition in the `Tag and Release` job to ensure that a pull request must not only be merged but also have the label `release` before proceeding with the tagging and release process.